### PR TITLE
✨ Builder: Pass all arguments and create API resource controllers

### DIFF
--- a/core/console/Commander.php
+++ b/core/console/Commander.php
@@ -43,12 +43,7 @@ class Commander
         }
 
         if (in_array($command, Builder::BUILD_COMMANDS)) {
-            if (!isset($this->args[1])) {
-                console_log(Helper::redText("Error: Please specify a name for the resource you want to build."));
-                exit(1);
-            }
-
-            return new Builder($command, $this->args[1]);
+            return new Builder($command, $this->args);
         }
 
         if (array_key_exists($command, $this->commands)) {

--- a/core/console/Helper.php
+++ b/core/console/Helper.php
@@ -14,22 +14,24 @@ class Helper
         console_log(self::purpleText("Candle - Elemental CLI"));
 
         console_log(self::yellowText("\nCommand \t\t\t\t Usage"));
-        console_log("======= \t\t\t\t =====\n");
+        console_log("======= \t\t\t\t =====");
 
         console_log(self::greenText("php candle ignite") . " \t\t\t Start the PHP server at default address & available port.");
         console_log(self::greenText("php candle ignite --host=[]") . " \t\t Start the PHP server at specified host address.");
         console_log(self::greenText("php candle ignite --port-[]") . " \t\t Start the PHP server at specified port.");
         console_log(self::greenText("php candle ignite --host=[] --port-[]") . " \t Start the PHP server at specified host address & port.\n");
 
-        console_log(self::greenText("php candle build:model [name]") . " \t\t Build a Model class with the specified name.");
-        console_log(self::greenText("php candle build:controller [name]") . " \t Build a Controller class with the specified name.");
-        console_log(self::greenText("php candle build:middleware [name]") . " \t Build a Middleware class with the specified name.\n");
+        console_log(self::greenText("php candle build:model [name] -f") . "\t Build a Model class with the specified name.");
+        console_log(self::greenText("php candle build:controller [name] --model=[model] --api -f") . "\n\t\t\t\t\t Build a Controller class with the specified name.");
+        console_log(self::greenText("php candle build:middleware [name] -f") . "\t Build a Middleware class with the specified name.");
+        console_log(self::greenText("php candle build:command [name] -f") . "\t Build a Command class with the specified name.");
+        console_log(self::blueText("\t\t\t\t\t Use ") . Helper::yellowText("-f") . Helper::blueText(" for build commands to overwrite the file when it already exists.\n"));
 
         console_log(self::greenText("php candle route:list") . " \t\t\t List all the routes registered within the App.");
         console_log(self::greenText("php candle help") . " \t\t\t List all the available commands.\n");
 
         console_log(self::yellowText("Custom commands"));
-        console_log("===============\n");
+        console_log("===============");
 
         foreach ($commands as $key => $command) {
             console_log(self::greenText("php candle $key") . " \t\t\t " . $command->getDescription());


### PR DESCRIPTION
This PR adds the following functionality:

- Pass all command arguments to `Builder`
- Abort build commands if overwriting existing file (can be forced with `-f`)
- Create API resource controllers using `--api`
- Create API resource controllers for specific models using `--model=[model]`
- Update `candle help` to reflect above changes.
- Add `build:command` to `candle help`.

<img width="582" alt="image" src="https://github.com/AneesMuzzafer/elemental/assets/1507671/19caa77c-5289-4688-a10a-17f83acfb56f">
