### PR TITLE
Builder: Automatically create controllers when creating models

### DIFF
--- a/core/console/Builder.php
+++ b/core/console/Builder.php
@@ -9,6 +9,10 @@ class Builder
     private string $name = "";
     private bool $forceCreate = false;
 
+    private array $modelConfig = [
+        'api' => false,
+        'controller' => false,
+    ];
     private array $controllerConfig = [
         'api' => false,
         'model' => null,
@@ -29,6 +33,16 @@ class Builder
             if ($arg == "-f") {
                 $this->forceCreate = true;
                 continue;
+            }
+
+            if ($this->resource == self::BUILD_MODEL) {
+                if ($arg == "--api") {
+                    $this->modelConfig['api'] = true;
+                }
+
+                if ($arg == "-c") {
+                    $this->modelConfig['controller'] = true;
+                }
             }
 
             if ($this->resource == self::BUILD_CONTROLLER) {
@@ -81,6 +95,18 @@ class Builder
         $content = $this->getModelContent();
 
         $this->createFile($dir, $this->name, $content);
+
+        if ($this->modelConfig['controller'] || $this->modelConfig['api']) {
+            $args = [];
+
+            if ($this->modelConfig['api']) {
+                $args[] = "--api";
+            }
+
+            $args[] = $this->name . "Controller";
+
+            return new Builder(self::BUILD_CONTROLLER, $args);
+        }
     }
 
     public function generateController()

--- a/core/console/Builder.php
+++ b/core/console/Builder.php
@@ -9,8 +9,10 @@ class Builder
     private string $name = "";
     private bool $forceCreate = false;
 
-    private bool $isApiController = false;
-    private ?string $associatedModel = null;
+    private array $controllerConfig = [
+        'api' => false,
+        'model' => null,
+    ];
 
     const BUILD_MODEL = "build:model";
     const BUILD_CONTROLLER = "build:controller";
@@ -31,14 +33,14 @@ class Builder
 
             if ($this->resource == self::BUILD_CONTROLLER) {
                 if ($arg == "--api") {
-                    $this->isApiController = true;
+                    $this->controllerConfig['api'] = true;
                 }
 
                 if (str_starts_with($arg, "--model=")) {
-                    $this->associatedModel = explode("=", $arg)[1];
+                    $this->controllerConfig['model'] = explode("=", $arg)[1];
 
-                    if (!file_exists(Application::getInstance()->basePath() . "/app/models/" . $this->associatedModel . ".php")) {
-                        console_log(Helper::redText("Error: The specified model (") . Helper::yellowText($this->associatedModel) . Helper::redText(") does not exist."));
+                    if (!file_exists(Application::getInstance()->basePath() . "/app/models/" . $this->controllerConfig['model'] . ".php")) {
+                        console_log(Helper::redText("Error: The specified model (") . Helper::yellowText($this->controllerConfig['model']) . Helper::redText(") does not exist."));
                         exit(1);
                     }
                 }
@@ -150,15 +152,15 @@ class $this->name extends Model
 
     private function getControllerContent()
     {
-        if ($this->isApiController) {
-            $modelParameter = is_null($this->associatedModel) ? "int \$id" : "$this->associatedModel $" . lcfirst($this->associatedModel);
+        if ($this->controllerConfig['api']) {
+            $modelParameter = is_null($this->controllerConfig['model']) ? "int \$id" : $this->controllerConfig['model'] . " $" . lcfirst($this->controllerConfig['model']);
 
             return "<?php
 
 namespace App\Controllers;
 
 use Core\Request\Request;
-" . (!is_null($this->associatedModel) ? "use App\Models\\" . $this->associatedModel . ";\n" : "") . "
+" . (!is_null($this->controllerConfig['model']) ? "use App\Models\\" . $this->controllerConfig['model'] . ";\n" : "") . "
 class $this->name
 {
     public function index()

--- a/core/console/Builder.php
+++ b/core/console/Builder.php
@@ -128,7 +128,7 @@ class Builder
             fwrite($file, $content);
             fclose($file);
 
-            console_log(Helper::greenText("File ") . Helper::purpleText("$filename.php") . Helper::greenText(" created successfully at ") . Helper::purpleText($dir));
+            console_log(Helper::greenText(ucfirst(explode(":", $this->resource)[1]) . " created successfully at ") . Helper::purpleText($filePath));
         } else {
             console_log(Helper::redText("Error: Unable to create the file."));
             exit(1);

--- a/core/console/Builder.php
+++ b/core/console/Builder.php
@@ -12,7 +12,12 @@ class Builder
     private bool $isApiController = false;
     private ?string $associatedModel = null;
 
-    const BUILD_COMMANDS = ["build:model", "build:controller", "build:middleware", "build:command"];
+    const BUILD_MODEL = "build:model";
+    const BUILD_CONTROLLER = "build:controller";
+    const BUILD_MIDDLEWARE = "build:middleware";
+    const BUILD_COMMAND = "build:command";
+
+    const BUILD_COMMANDS = [self::BUILD_MODEL, self::BUILD_CONTROLLER, self::BUILD_MIDDLEWARE, self::BUILD_COMMAND];
 
     public function __construct(private string $resource, private array $args)
     {
@@ -24,7 +29,7 @@ class Builder
                 continue;
             }
 
-            if ($this->resource == self::BUILD_COMMANDS[1]) {
+            if ($this->resource == self::BUILD_CONTROLLER) {
                 if ($arg == "--api") {
                     $this->isApiController = true;
                 }
@@ -55,13 +60,13 @@ class Builder
     public function generateResource()
     {
         switch ($this->resource) {
-            case self::BUILD_COMMANDS[0]:
+            case self::BUILD_MODEL:
                 return $this->generateModel();
-            case self::BUILD_COMMANDS[1]:
+            case self::BUILD_CONTROLLER:
                 return $this->generateController();
-            case self::BUILD_COMMANDS[2]:
+            case self::BUILD_MIDDLEWARE:
                 return $this->generateMiddleware();
-            case self::BUILD_COMMANDS[3]:
+            case self::BUILD_COMMAND:
                 return $this->generateCommand();
         }
     }

--- a/core/console/Builder.php
+++ b/core/console/Builder.php
@@ -97,7 +97,7 @@ class Builder
         $this->createFile($dir, $this->name, $content);
 
         if ($this->modelConfig['controller'] || $this->modelConfig['api']) {
-            $args = [];
+            $args = ["--model=" . $this->name];
 
             if ($this->modelConfig['api']) {
                 $args[] = "--api";

--- a/core/console/Commander.php
+++ b/core/console/Commander.php
@@ -42,6 +42,10 @@ class Commander
             return new Helper($this->commands);
         }
 
+        if ($command === "list") {
+            return new Helper($this->commands);
+        }
+
         if (in_array($command, Builder::BUILD_COMMANDS)) {
             return new Builder($command, $this->args);
         }

--- a/core/console/Helper.php
+++ b/core/console/Helper.php
@@ -25,7 +25,7 @@ class Helper
         console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("-c") . Helper::blueText(" to create a controller for the model."));
         console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--api") . Helper::blueText(" to create an API controller."));
         console_log(self::greenText("php candle build:controller [name] --model=[model] --api -f") . "\n\t\t\t\t\t\t Build a Controller class with the specified name.");
-        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--model=[model]") . Helper::blueText(" to set the model name for the controller."));
+        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--model=[model]") . Helper::blueText(" to set the model for the controller."));
         console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--api") . Helper::blueText(" to create an API controller."));
         console_log(self::greenText("php candle build:middleware [name] -f") . "\t\t Build a Middleware class with the specified name.");
         console_log(self::greenText("php candle build:command [name] -f") . "\t\t Build a Command class with the specified name.");

--- a/core/console/Helper.php
+++ b/core/console/Helper.php
@@ -13,28 +13,32 @@ class Helper
     {
         console_log(self::purpleText("Candle - Elemental CLI"));
 
-        console_log(self::yellowText("\nCommand \t\t\t\t Usage"));
-        console_log("======= \t\t\t\t =====");
+        console_log(self::yellowText("\nCommand \t\t\t\t\t Usage"));
+        console_log("======= \t\t\t\t\t =====");
 
-        console_log(self::greenText("php candle ignite") . " \t\t\t Start the PHP server at default address & available port.");
-        console_log(self::greenText("php candle ignite --host=[]") . " \t\t Start the PHP server at specified host address.");
-        console_log(self::greenText("php candle ignite --port-[]") . " \t\t Start the PHP server at specified port.");
-        console_log(self::greenText("php candle ignite --host=[] --port-[]") . " \t Start the PHP server at specified host address & port.\n");
+        console_log(self::greenText("php candle ignite") . " \t\t\t\t Start the PHP server at default address & available port.");
+        console_log(self::greenText("php candle ignite --host=[]") . " \t\t\t Start the PHP server at specified host address.");
+        console_log(self::greenText("php candle ignite --port-[]") . " \t\t\t Start the PHP server at specified port.");
+        console_log(self::greenText("php candle ignite --host=[] --port-[]") . " \t\t Start the PHP server at specified host address & port.\n");
 
-        console_log(self::greenText("php candle build:model [name] -f") . "\t Build a Model class with the specified name.");
-        console_log(self::greenText("php candle build:controller [name] --model=[model] --api -f") . "\n\t\t\t\t\t Build a Controller class with the specified name.");
-        console_log(self::greenText("php candle build:middleware [name] -f") . "\t Build a Middleware class with the specified name.");
-        console_log(self::greenText("php candle build:command [name] -f") . "\t Build a Command class with the specified name.");
-        console_log(self::blueText("\t\t\t\t\t Use ") . Helper::yellowText("-f") . Helper::blueText(" for build commands to overwrite the file when it already exists.\n"));
+        console_log(self::greenText("php candle build:model [name] -c --api -f") . "\t Build a Model class with the specified name.");
+        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("-c") . Helper::blueText(" to create a controller for the model."));
+        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--api") . Helper::blueText(" to create an API controller."));
+        console_log(self::greenText("php candle build:controller [name] --model=[model] --api -f") . "\n\t\t\t\t\t\t Build a Controller class with the specified name.");
+        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--model=[model]") . Helper::blueText(" to set the model name for the controller."));
+        console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("--api") . Helper::blueText(" to create an API controller."));
+        console_log(self::greenText("php candle build:middleware [name] -f") . "\t\t Build a Middleware class with the specified name.");
+        console_log(self::greenText("php candle build:command [name] -f") . "\t\t Build a Command class with the specified name.");
+        console_log(self::blueText("\n\t\t\t\t\t\t Use ") . Helper::yellowText("-f") . Helper::blueText(" for build commands to overwrite the file when it already exists.\n"));
 
-        console_log(self::greenText("php candle route:list") . " \t\t\t List all the routes registered within the App.");
-        console_log(self::greenText("php candle help") . " \t\t\t List all the available commands.\n");
+        console_log(self::greenText("php candle route:list") . " \t\t\t\t List all the routes registered within the App.");
+        console_log(self::greenText("php candle help") . " \t\t\t\t List all the available commands.\n");
 
         console_log(self::yellowText("Custom commands"));
         console_log("===============");
 
         foreach ($commands as $key => $command) {
-            console_log(self::greenText("php candle $key") . " \t\t\t " . $command->getDescription());
+            console_log(self::greenText("php candle $key") . " \t\t\t\t " . $command->getDescription());
         }
     }
 

--- a/core/console/Helper.php
+++ b/core/console/Helper.php
@@ -18,8 +18,8 @@ class Helper
 
         console_log(self::greenText("php candle ignite") . " \t\t\t\t Start the PHP server at default address & available port.");
         console_log(self::greenText("php candle ignite --host=[]") . " \t\t\t Start the PHP server at specified host address.");
-        console_log(self::greenText("php candle ignite --port-[]") . " \t\t\t Start the PHP server at specified port.");
-        console_log(self::greenText("php candle ignite --host=[] --port-[]") . " \t\t Start the PHP server at specified host address & port.\n");
+        console_log(self::greenText("php candle ignite --port=[]") . " \t\t\t Start the PHP server at specified port.");
+        console_log(self::greenText("php candle ignite --host=[] --port=[]") . " \t\t Start the PHP server at specified host address & port.\n");
 
         console_log(self::greenText("php candle build:model [name] -c --api -f") . "\t Build a Model class with the specified name.");
         console_log(self::blueText("\t\t\t\t\t\t Use ") . Helper::yellowText("-c") . Helper::blueText(" to create a controller for the model."));


### PR DESCRIPTION
This PR adds the following functionality:

- Option to automatically create controllers when creating models (Story -> StoryController).
- Option to create API controllers when creating models.
- Update file creation message to enable control-click to open file in editor.
- Refactor build command list.
- Refactor build command configuration.
- Add an alias for candle `help` command: `list`.
- Update `candle help` / `candle list` to reflect above changes.
- Fix typo in command list for server startup port (`-` -> `=`)

<img width="620" alt="image" src="https://github.com/AneesMuzzafer/elemental/assets/1507671/6a477486-362b-4764-b60c-44a3e6c5638e">
