### PR TITLE
New Middleware: AllowCORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,6 @@ $mailService =  Application::instance()->make(MailService::class);
 
 The `make` method is particularly useful when attempting to resolve a class from within a code component where it's impractical to inject a dependency using type-hinting. In such scenarios, you can explicitly request the application's Dependency Injection Container to resolve an instance for you.
 
-
-
-
 ## Routing
 
 Routes are defined in the `app\routes.php` file, allowing developers to easily register various routes to handle different HTTP requests.
@@ -283,7 +280,6 @@ Route::get("/story/{id}", function ($id) {/*...*/});
 You may define as many route parameters as required by your route:
 
 ```php
-
 Route::post("story/edit/{id}", [StoryController::class, "edit"]);
 
 Route::get("story/{story_id}/comment/{comment_id}", [StoryController::class, "comment"]);
@@ -321,9 +317,7 @@ In the context of routes or controller actions, models are defined using type-hi
 use App\Models\User;
 
 Route::get('/users/{user}', function  (User  $user) {
-
-return  $user->email;
-
+    return  $user->email;
 });
 ```
 
@@ -365,7 +359,6 @@ php candle route:list
 ```
 
 ## Controllers
-
 
 Rather than consolidating all request handling logic within closures in your route files, consider structuring this behavior through "controller" classes. Controllers allow you to organize related request handling logic into a cohesive class. For instance, a `UserController` class could manage various incoming requests related to users, such as displaying, creating, updating, and deleting users. These controller classes are conventionally stored in the `app/Controllers` directory.
 
@@ -481,7 +474,7 @@ class StoryController
 {
     public function update(string $id, Request $request)
     {
-        // Update the story...
+        // Update $story
 
         return redirect("/story/$story->id");
     }
@@ -542,7 +535,7 @@ class StoryController
 {
     public function update(string $id, Request $request)
     {
-        // Update the story...
+        // Update $story
         return redirect("/story/$story->id");
     }
 }
@@ -662,7 +655,7 @@ $xmlData = $request->xml();
 Every route and controller is expected to produce a response for delivery to the user's browser. Elemental offers various methods for generating responses. The simplest form of response involves returning a string directly from a route or controller. The framework will seamlessly convert this string into a complete HTTP response.
 ```php
 Route::get('/', function  () {
-	return  'Hello World';
+	return 'Hello World';
 });
 ```
 
@@ -688,10 +681,10 @@ Route::get('/home', function(Response $response) {
 			->setStatusCode(200)
 			->setContent("Hello World");
 
-	return  response;
+	return $response;
 });
 ```
-You can ofcourse return a `view` from a controller. However,  If you need control over the response's status and headers but also need to return a `view` as the response's content, you can do that as following:
+You can of course return a `view` from a controller. However,  If you need control over the response's status and headers but also need to return a `view` as the response's content, you can do that as following:
 
 ```php
 
@@ -751,7 +744,7 @@ However, for simplicity a helper method `redirect()` is also available globally 
 use Core\Response\Response;
 
 Route::post('/story/create', function  () {
-	if(!some condition)
+	if(!$someCondition)
 		return redirect('/story', 204);
 });
 ```
@@ -769,9 +762,7 @@ Route::post('/post', function  () {
 });
 ```
 
-
 ## Middleware
-
 
 Middleware offers a convenient mechanism to examine and filter incoming HTTP requests to your application. For instance, you can develop middleware to validate the authentication status of your application's user. If the user is not authenticated, the middleware will redirect them to the login screen. Conversely, if the user is authenticated, the middleware will permit the request to advance deeper into the application.
 
@@ -926,7 +917,6 @@ return view('layouts.MainLayout', $data);
 ### Layouts
 
 Elemental provides a convenient way to maintain the same layout across multiple views, reducing code duplication. A layout is itself a view file containing a placeholder `{{ content }}`. When a view is returned with the layout, the final view is compiled by putting the view inside the layout's content.
-
 
 Elemental provides a convenient way to maintain the same layout across multiple views, reducing code duplication. A layout is a view file that incorporates a designated placeholder, denoted by `{{ content }}`. When a view is returned using a specific layout, the composition is achieved by embedding the content of the view within the designated placeholder in the layout. This approach streamlines the organization of views and enhances code maintainability by centralizing common layout elements.
 
@@ -1516,7 +1506,6 @@ class Migration extends Command
 
 ```
 
-
 It is recommended to type-hint dependencies inside the handle method as opposed to inside the constructor of the command class.
 
 To execute these migration commands in the command line:
@@ -1529,7 +1518,6 @@ php candle migrate delete
 As you can see, generating commands are very powerful and can be helpful to achieve a variety of functionalities. Here, a custom migration handler has been built. You can expand and organize the above structure or create a custom Migration Service that can handle your migration logic.
 
 Commands can also be used for handling task scheduling. You may create a command that executes some logic, and then pass the command to your operating systems CRON handler.
-
 
 ## Helpers
 
@@ -1597,10 +1585,7 @@ The `redirect` function returns a redirect HTTP response and is used to redirect
 return  redirect('/home');
 ```
 
-
-
 ## Exception Handler
-
 
 Elemental provides a convenient way to handle all the exceptions thrown by the app.
 
@@ -1699,10 +1684,7 @@ class YourClass {
 
 By doing this, you have a clean and organized way to retrieve configuration values within your application.
 
-
 This approach keeps your configuration centralized and allows for easy changes based on the environment. It also promotes a clean and maintainable codebase.
-
-
 
 ## Facades
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Elemental is a PHP framework developed from scratch for dynamic, user-friendly c
 - [Facades](#facades)
 - [No External Dependency](#why-choose-elemental)
 
-
-
 ## Demo - Inkwell
 
 To showcase the capabilities of Elemental, a fully working platform called **[Inkwell](https://inkwell.anees.dev)** has been developed using Elemental. Inkwell is a unique space dedicated to the pure essence of storytelling. In line with Elemental's goal of having no external dependencies, Inkwell has been crafted using plain HTML, CSS, JS, and PHP only.
@@ -30,7 +28,6 @@ To showcase the capabilities of Elemental, a fully working platform called **[In
 Feel free to delve into both the live platform and the corresponding codebase. Explore Inkwell's features to understand how Elemental can be harnessed for your own projects.
 
 See the [inspiration](#inspiration) behind the creation of **Elemental**.
-
 
 ## Why Choose Elemental?
 
@@ -46,7 +43,7 @@ In fact, you are encouraged not just to follow the path but to venture off the b
 
 #### For an exhaustive reference guide, explore the [**API Documentation**](https://aneesmuzzafer.github.io/elemental) to gain insights into Elemental's API.
 
- ___
+---
 
 ### Content
 
@@ -65,7 +62,6 @@ In fact, you are encouraged not just to follow the path but to venture off the b
  13. [Exception Handler](#exception-handler)
  14. [Configuration](#configuration)
  15. [Facades](#facades)
-
 
 ## Getting Started
 

--- a/app/middlewares/AllowCORS.php
+++ b/app/middlewares/AllowCORS.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Middlewares;
+
+use Closure;
+use Core\Request\Request;
+use Core\Response\ResponseGenerator;
+
+class AllowCORS
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $response = (new ResponseGenerator($next($request)))->toResponse();
+
+        $response->setHeader('Access-Control-Allow-Origin', '*');
+        $response->setHeader('Access-Control-Allow-Methods', '*');
+
+        return $response;
+    }
+}

--- a/core/console/Helper.php
+++ b/core/console/Helper.php
@@ -31,7 +31,8 @@ class Helper
         console_log(self::greenText("php candle build:command [name] -f") . "\t\t Build a Command class with the specified name.");
         console_log(self::blueText("\n\t\t\t\t\t\t Use ") . Helper::yellowText("-f") . Helper::blueText(" for build commands to overwrite the file when it already exists.\n"));
 
-        console_log(self::greenText("php candle route:list") . " \t\t\t\t List all the routes registered within the App.");
+        console_log(self::greenText("php candle route:list") . " \t\t\t\t List all the registered routes.");
+        console_log(self::greenText("php candle list") . " \t\t\t\t List all the available commands. Alias of " . self::yellowText("php candle help") . ".");
         console_log(self::greenText("php candle help") . " \t\t\t\t List all the available commands.\n");
 
         console_log(self::yellowText("Custom commands"));

--- a/core/engine/WebEngine.php
+++ b/core/engine/WebEngine.php
@@ -33,7 +33,6 @@ class WebEngine implements WebEngineContract
                     return $this->process($route, $args);
                 })->execute();
         } catch (\Throwable $e) {
-
             $response = $this->app->make(Handler::class)->handleException($e);
         }
 

--- a/core/exception/ExceptionHandler.php
+++ b/core/exception/ExceptionHandler.php
@@ -21,15 +21,19 @@ class ExceptionHandler
         if ($e instanceof RouteNotFoundException) {
             $response = $this->response->setContent($this->formatErrorMessage($e, "Route Not Found Exception"));
         }
+
         if ($e instanceof ModelNotFoundException) {
             $response = $this->response->setContent($this->formatErrorMessage($e, "Model Not Found Exception"));
         }
+
         if ($e instanceof RouterException) {
             $response = $this->response->setContent($this->formatErrorMessage($e, "Router Exception"));
         }
+
         if ($e instanceof ViewNotFoundException) {
             $response = $this->response->setContent($this->formatErrorMessage($e, "View Not Found Exception"));
         }
+
         if ($e instanceof AppException) {
             $response = $this->response->setContent($this->formatErrorMessage($e, "App Exception"));
         }

--- a/core/model/Model.php
+++ b/core/model/Model.php
@@ -36,6 +36,7 @@ class Model
     public static function create(array $data)
     {
         $model = new static();
+
         foreach ($data as $column => $value) {
             $model->data[$column] = $value;
         }
@@ -46,6 +47,7 @@ class Model
     public static function find($id)
     {
         $model = new static();
+
         return $model->getFromPrimaryKey($id);
     }
 

--- a/docs/classes/App-Exceptions-Handler.html
+++ b/docs/classes/App-Exceptions-Handler.html
@@ -361,7 +361,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/exception/ExceptionHandler.php"><a href="files/core-exception-exceptionhandler.html"><abbr title="core/exception/ExceptionHandler.php">ExceptionHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 

--- a/docs/classes/App-Middlewares-AllowCORS.html
+++ b/docs/classes/App-Middlewares-AllowCORS.html
@@ -76,7 +76,7 @@
                 
             </li>
                     <li>
-                <a href="namespaces/app-middlewares.html" class="-active">Middlewares</a>
+                <a href="namespaces/app-middlewares.html" class="">Middlewares</a>
                 
             </li>
                     <li>
@@ -172,33 +172,183 @@
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
             <li class="phpdocumentor-breadcrumb"><a href="namespaces/app.html">App</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/app-middlewares.html">Middlewares</a></li>
     </ul>
 
-    <article class="phpdocumentor-element -namespace">
-        <h2 class="phpdocumentor-content__title">Middlewares</h2>
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    AllowCORS
+
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/Elemental.html">Elemental</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="app/middlewares/AllowCORS.php"><a href="files/app-middlewares-allowcors.html"><abbr title="app/middlewares/AllowCORS.php">AllowCORS.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">9</span>
+
+    </aside>
 
         
+    <section class="phpdocumentor-description"></section>
 
-<h3 id="interfaces_class_traits">
-    Interfaces, Classes, Traits and Enums
-    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-    
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-AllowCORS.html"><abbr title="\App\Middlewares\AllowCORS">AllowCORS</abbr></a></dt>
-        <dd></dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-Logger.html"><abbr title="\App\Middlewares\Logger">Logger</abbr></a></dt>
-        <dd></dd>
-    
-    
-    </dl>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/App-Middlewares-AllowCORS.html#method_handle">handle()</a>
+    <span>
+                                &nbsp;: mixed    </span>
+</dt>
+<dd></dd>
+
+        </dl>
 
 
 
         
 
         
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/App-Middlewares-AllowCORS.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_handle">
+        handle()
+        <a href="classes/App-Middlewares-AllowCORS.html#method_handle" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="app/middlewares/AllowCORS.php"><a href="files/app-middlewares-allowcors.html"><abbr title="app/middlewares/AllowCORS.php">AllowCORS.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">11</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">handle</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Core-Request-Request.html"><abbr title="\Core\Request\Request">Request</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$request</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Closure">Closure</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$next</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$request</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/Core-Request-Request.html"><abbr title="\Core\Request\Request">Request</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$next</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Closure">Closure</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">mixed</span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
     </article>
                 <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
     <section class="phpdocumentor-search-results__dialog">
@@ -213,7 +363,7 @@
 </section>
             </div>
         </div>
-        <a href="namespaces/app-middlewares.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/App-Middlewares-AllowCORS.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 

--- a/docs/classes/App-Models-User.html
+++ b/docs/classes/App-Models-User.html
@@ -571,7 +571,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">258</span>
+    <span class="phpdocumentor-element-found-in__line">260</span>
 
     </aside>
 
@@ -615,7 +615,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">267</span>
+    <span class="phpdocumentor-element-found-in__line">269</span>
 
     </aside>
 
@@ -667,7 +667,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">200</span>
+    <span class="phpdocumentor-element-found-in__line">202</span>
 
     </aside>
 
@@ -711,7 +711,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">213</span>
+    <span class="phpdocumentor-element-found-in__line">215</span>
 
     </aside>
 
@@ -815,7 +815,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">253</span>
+    <span class="phpdocumentor-element-found-in__line">255</span>
 
     </aside>
 
@@ -848,7 +848,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">146</span>
+    <span class="phpdocumentor-element-found-in__line">148</span>
 
     </aside>
 
@@ -892,7 +892,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">127</span>
+    <span class="phpdocumentor-element-found-in__line">129</span>
 
     </aside>
 
@@ -925,7 +925,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">46</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -969,7 +969,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">52</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 
@@ -1013,7 +1013,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">90</span>
+    <span class="phpdocumentor-element-found-in__line">92</span>
 
     </aside>
 
@@ -1046,7 +1046,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">272</span>
+    <span class="phpdocumentor-element-found-in__line">274</span>
 
     </aside>
 
@@ -1079,7 +1079,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">71</span>
+    <span class="phpdocumentor-element-found-in__line">73</span>
 
     </aside>
 
@@ -1164,7 +1164,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">108</span>
+    <span class="phpdocumentor-element-found-in__line">110</span>
 
     </aside>
 
@@ -1216,7 +1216,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">163</span>
+    <span class="phpdocumentor-element-found-in__line">165</span>
 
     </aside>
 
@@ -1260,7 +1260,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">283</span>
+    <span class="phpdocumentor-element-found-in__line">285</span>
 
     </aside>
 

--- a/docs/classes/Core-Console-Builder.html
+++ b/docs/classes/Core-Console-Builder.html
@@ -214,13 +214,69 @@
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/Core-Console-Builder.html#constant_BUILD_COMMAND">BUILD_COMMAND</a>
+    <span>
+        &nbsp;= &quot;build:command&quot;                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
     <a href="classes/Core-Console-Builder.html#constant_BUILD_COMMANDS">BUILD_COMMANDS</a>
     <span>
-        &nbsp;= [&quot;build:model&quot;, &quot;build:controller&quot;, &quot;build:middleware&quot;, &quot;build:command&quot;]                            </span>
+        &nbsp;= [self::BUILD_MODEL, self::BUILD_CONTROLLER, self::BUILD_MIDDLEWARE, self::BUILD_COMMAND]                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/Core-Console-Builder.html#constant_BUILD_CONTROLLER">BUILD_CONTROLLER</a>
+    <span>
+        &nbsp;= &quot;build:controller&quot;                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/Core-Console-Builder.html#constant_BUILD_MIDDLEWARE">BUILD_MIDDLEWARE</a>
+    <span>
+        &nbsp;= &quot;build:middleware&quot;                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/Core-Console-Builder.html#constant_BUILD_MODEL">BUILD_MODEL</a>
+    <span>
+        &nbsp;= &quot;build:model&quot;                            </span>
 </dt>
 <dd></dd>
 
                     <dt class="phpdocumentor-table-of-contents__entry -property -private">
+    <a href="classes/Core-Console-Builder.html#property_args">$args</a>
+    <span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -private">
+    <a href="classes/Core-Console-Builder.html#property_controllerConfig">$controllerConfig</a>
+    <span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -private">
+    <a href="classes/Core-Console-Builder.html#property_forceCreate">$forceCreate</a>
+    <span>
+                        &nbsp;: bool            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -private">
+    <a href="classes/Core-Console-Builder.html#property_modelConfig">$modelConfig</a>
+    <span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -private">
     <a href="classes/Core-Console-Builder.html#property_name">$name</a>
     <span>
                         &nbsp;: string            </span>
@@ -322,6 +378,35 @@
             <a href="classes/Core-Console-Builder.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_BUILD_COMMAND">
+        BUILD_COMMAND
+        <a href="classes/Core-Console-Builder.html#constant_BUILD_COMMAND" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">24</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">BUILD_COMMAND</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;build:command&quot;</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_BUILD_COMMANDS">
         BUILD_COMMANDS
         <a href="classes/Core-Console-Builder.html#constant_BUILD_COMMANDS" class="headerlink"><i class="fas fa-link"></i></a>
@@ -330,7 +415,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">12</span>
+    <span class="phpdocumentor-element-found-in__line">26</span>
 
     </aside>
 
@@ -339,7 +424,94 @@
     <span class="phpdocumentor-signature__visibility">public</span>
         <span class="phpdocumentor-signature__type">mixed</span>
     <span class="phpdocumentor-signature__name">BUILD_COMMANDS</span>
-    = <span class="phpdocumentor-signature__default-value">[&quot;build:model&quot;, &quot;build:controller&quot;, &quot;build:middleware&quot;, &quot;build:command&quot;]</span>
+    = <span class="phpdocumentor-signature__default-value">[self::BUILD_MODEL, self::BUILD_CONTROLLER, self::BUILD_MIDDLEWARE, self::BUILD_COMMAND]</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_BUILD_CONTROLLER">
+        BUILD_CONTROLLER
+        <a href="classes/Core-Console-Builder.html#constant_BUILD_CONTROLLER" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">22</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">BUILD_CONTROLLER</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;build:controller&quot;</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_BUILD_MIDDLEWARE">
+        BUILD_MIDDLEWARE
+        <a href="classes/Core-Console-Builder.html#constant_BUILD_MIDDLEWARE" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">23</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">BUILD_MIDDLEWARE</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;build:middleware&quot;</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_BUILD_MODEL">
+        BUILD_MODEL
+        <a href="classes/Core-Console-Builder.html#constant_BUILD_MODEL" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">21</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">BUILD_MODEL</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;build:model&quot;</span>
 </code>
 
 
@@ -365,9 +537,77 @@
             -private
                                                         "
 >
-    <h4 class="phpdocumentor-element__name" id="property_name">
-        $name
-        <a href="classes/Core-Console-Builder.html#property_name" class="headerlink"><i class="fas fa-link"></i></a>
+    <h4 class="phpdocumentor-element__name" id="property_args">
+        $args
+        <a href="classes/Core-Console-Builder.html#property_args" class="headerlink"><i class="fas fa-link"></i></a>
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">28</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+        <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
+    <span class="phpdocumentor-signature__name">$args</span>
+    </code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_controllerConfig">
+        $controllerConfig
+        <a href="classes/Core-Console-Builder.html#property_controllerConfig" class="headerlink"><i class="fas fa-link"></i></a>
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">16</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+        <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
+    <span class="phpdocumentor-signature__name">$controllerConfig</span>
+     = <span class="phpdocumentor-signature__default-value">[&#039;api&#039; =&gt; false, &#039;model&#039; =&gt; null]</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_forceCreate">
+        $forceCreate
+        <a href="classes/Core-Console-Builder.html#property_forceCreate" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
@@ -381,9 +621,77 @@
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
+        <span class="phpdocumentor-signature__type">bool</span>
+    <span class="phpdocumentor-signature__name">$forceCreate</span>
+     = <span class="phpdocumentor-signature__default-value">false</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_modelConfig">
+        $modelConfig
+        <a href="classes/Core-Console-Builder.html#property_modelConfig" class="headerlink"><i class="fas fa-link"></i></a>
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">12</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+        <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
+    <span class="phpdocumentor-signature__name">$modelConfig</span>
+     = <span class="phpdocumentor-signature__default-value">[&#039;api&#039; =&gt; false, &#039;controller&#039; =&gt; false]</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_name">
+        $name
+        <a href="classes/Core-Console-Builder.html#property_name" class="headerlink"><i class="fas fa-link"></i></a>
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">9</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
         <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">$name</span>
-    </code>
+     = <span class="phpdocumentor-signature__default-value">&quot;&quot;</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -408,7 +716,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">9</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
@@ -446,14 +754,14 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">14</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$resource</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$resource</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$args</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -468,8 +776,8 @@
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$name</span>
-                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                <span class="phpdocumentor-signature__argument__name">$args</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -498,7 +806,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">75</span>
+    <span class="phpdocumentor-element-found-in__line">142</span>
 
     </aside>
 
@@ -558,7 +866,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">65</span>
+    <span class="phpdocumentor-element-found-in__line">132</span>
 
     </aside>
 
@@ -591,7 +899,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">112</span>
 
     </aside>
 
@@ -624,7 +932,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">55</span>
+    <span class="phpdocumentor-element-found-in__line">122</span>
 
     </aside>
 
@@ -657,7 +965,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">90</span>
 
     </aside>
 
@@ -690,7 +998,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">21</span>
+    <span class="phpdocumentor-element-found-in__line">76</span>
 
     </aside>
 
@@ -723,7 +1031,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">139</span>
+    <span class="phpdocumentor-element-found-in__line">253</span>
 
     </aside>
 
@@ -756,7 +1064,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">106</span>
+    <span class="phpdocumentor-element-found-in__line">179</span>
 
     </aside>
 
@@ -789,7 +1097,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">121</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -822,7 +1130,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Builder.php"><a href="files/core-console-builder.html"><abbr title="core/console/Builder.php">Builder.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">92</span>
+    <span class="phpdocumentor-element-found-in__line">164</span>
 
     </aside>
 

--- a/docs/classes/Core-Console-Commander.html
+++ b/docs/classes/Core-Console-Commander.html
@@ -409,7 +409,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Commander.php"><a href="files/core-console-commander.html"><abbr title="core/console/Commander.php">Commander.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">89</span>
+    <span class="phpdocumentor-element-found-in__line">88</span>
 
     </aside>
 
@@ -461,7 +461,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Commander.php"><a href="files/core-console-commander.html"><abbr title="core/console/Commander.php">Commander.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">74</span>
+    <span class="phpdocumentor-element-found-in__line">73</span>
 
     </aside>
 
@@ -494,7 +494,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Commander.php"><a href="files/core-console-commander.html"><abbr title="core/console/Commander.php">Commander.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">94</span>
+    <span class="phpdocumentor-element-found-in__line">93</span>
 
     </aside>
 
@@ -538,7 +538,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Commander.php"><a href="files/core-console-commander.html"><abbr title="core/console/Commander.php">Commander.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">79</span>
+    <span class="phpdocumentor-element-found-in__line">78</span>
 
     </aside>
 
@@ -604,7 +604,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Commander.php"><a href="files/core-console-commander.html"><abbr title="core/console/Commander.php">Commander.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">67</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 

--- a/docs/classes/Core-Console-Helper.html
+++ b/docs/classes/Core-Console-Helper.html
@@ -220,6 +220,41 @@
 </dt>
 <dd></dd>
 
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Core-Console-Helper.html#method_blueText">blueText()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Core-Console-Helper.html#method_greenText">greenText()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Core-Console-Helper.html#method_purpleText">purpleText()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Core-Console-Helper.html#method_redText">redText()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/Core-Console-Helper.html#method_yellowText">yellowText()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd></dd>
+
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a href="classes/Core-Console-Helper.html#method_logAllCommands">logAllCommands()</a>
     <span>
@@ -280,6 +315,226 @@
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">mixed</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_blueText">
+        blueText()
+        <a href="classes/Core-Console-Helper.html#method_blueText" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Helper.php"><a href="files/core-console-helper.html"><abbr title="core/console/Helper.php">Helper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">66</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">blueText</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_greenText">
+        greenText()
+        <a href="classes/Core-Console-Helper.html#method_greenText" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Helper.php"><a href="files/core-console-helper.html"><abbr title="core/console/Helper.php">Helper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">46</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">greenText</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_purpleText">
+        purpleText()
+        <a href="classes/Core-Console-Helper.html#method_purpleText" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Helper.php"><a href="files/core-console-helper.html"><abbr title="core/console/Helper.php">Helper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">56</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">purpleText</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_redText">
+        redText()
+        <a href="classes/Core-Console-Helper.html#method_redText" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Helper.php"><a href="files/core-console-helper.html"><abbr title="core/console/Helper.php">Helper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">61</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">redText</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_yellowText">
+        yellowText()
+        <a href="classes/Core-Console-Helper.html#method_yellowText" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Helper.php"><a href="files/core-console-helper.html"><abbr title="core/console/Helper.php">Helper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">51</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">yellowText</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+            </dl>
+
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
         
     

--- a/docs/classes/Core-Console-Lister.html
+++ b/docs/classes/Core-Console-Lister.html
@@ -228,6 +228,13 @@
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
+    <a href="classes/Core-Console-Lister.html#method_logAllRoutes">logAllRoutes()</a>
+    <span>
+                                &nbsp;: void    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a href="classes/Core-Console-Lister.html#method_logRoutes">logRoutes()</a>
     <span>
                                 &nbsp;: mixed    </span>
@@ -316,6 +323,39 @@
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">mixed</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -private
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method_logAllRoutes">
+        logAllRoutes()
+        <a href="classes/Core-Console-Lister.html#method_logAllRoutes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="core/console/Lister.php"><a href="files/core-console-lister.html"><abbr title="core/console/Lister.php">Lister.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">40</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">private</span>
+                    <span class="phpdocumentor-signature__name">logAllRoutes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
             &mdash;
         
     

--- a/docs/classes/Core-Console-Server.html
+++ b/docs/classes/Core-Console-Server.html
@@ -251,14 +251,14 @@
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a href="classes/Core-Console-Server.html#method_isValidHost">isValidHost()</a>
     <span>
-                                &nbsp;: mixed    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -private">
     <a href="classes/Core-Console-Server.html#method_isValidPort">isValidPort()</a>
     <span>
-                                &nbsp;: mixed    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd></dd>
 
@@ -505,7 +505,7 @@
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">isValidHost</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$host</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">isValidHost</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$host</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -524,7 +524,7 @@
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">mixed</span>
+    <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
         
     
@@ -542,14 +542,14 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/console/Server.php"><a href="files/core-console-server.html"><abbr title="core/console/Server.php">Server.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">76</span>
+    <span class="phpdocumentor-element-found-in__line">78</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-                    <span class="phpdocumentor-signature__name">isValidPort</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$port</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">isValidPort</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$port</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -568,7 +568,7 @@
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">mixed</span>
+    <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
         
     

--- a/docs/classes/Core-Engine-WebEngine.html
+++ b/docs/classes/Core-Engine-WebEngine.html
@@ -414,7 +414,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/engine/WebEngine.php"><a href="files/core-engine-webengine.html"><abbr title="core/engine/WebEngine.php">WebEngine.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">49</span>
 
     </aside>
 
@@ -458,7 +458,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/engine/WebEngine.php"><a href="files/core-engine-webengine.html"><abbr title="core/engine/WebEngine.php">WebEngine.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">43</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 

--- a/docs/classes/Core-Exception-ExceptionHandler.html
+++ b/docs/classes/Core-Exception-ExceptionHandler.html
@@ -358,7 +358,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/exception/ExceptionHandler.php"><a href="files/core-exception-exceptionhandler.html"><abbr title="core/exception/ExceptionHandler.php">ExceptionHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 
@@ -410,7 +410,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/exception/ExceptionHandler.php"><a href="files/core-exception-exceptionhandler.html"><abbr title="core/exception/ExceptionHandler.php">ExceptionHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">49</span>
 
     </aside>
 

--- a/docs/classes/Core-Model-Model.html
+++ b/docs/classes/Core-Model-Model.html
@@ -568,7 +568,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">258</span>
+    <span class="phpdocumentor-element-found-in__line">260</span>
 
     </aside>
 
@@ -612,7 +612,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">267</span>
+    <span class="phpdocumentor-element-found-in__line">269</span>
 
     </aside>
 
@@ -664,7 +664,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">200</span>
+    <span class="phpdocumentor-element-found-in__line">202</span>
 
     </aside>
 
@@ -708,7 +708,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">213</span>
+    <span class="phpdocumentor-element-found-in__line">215</span>
 
     </aside>
 
@@ -812,7 +812,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">253</span>
+    <span class="phpdocumentor-element-found-in__line">255</span>
 
     </aside>
 
@@ -845,7 +845,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">146</span>
+    <span class="phpdocumentor-element-found-in__line">148</span>
 
     </aside>
 
@@ -889,7 +889,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">127</span>
+    <span class="phpdocumentor-element-found-in__line">129</span>
 
     </aside>
 
@@ -922,7 +922,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">46</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -966,7 +966,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">52</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 
@@ -1010,7 +1010,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">90</span>
+    <span class="phpdocumentor-element-found-in__line">92</span>
 
     </aside>
 
@@ -1043,7 +1043,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">272</span>
+    <span class="phpdocumentor-element-found-in__line">274</span>
 
     </aside>
 
@@ -1076,7 +1076,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">71</span>
+    <span class="phpdocumentor-element-found-in__line">73</span>
 
     </aside>
 
@@ -1161,7 +1161,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">108</span>
+    <span class="phpdocumentor-element-found-in__line">110</span>
 
     </aside>
 
@@ -1213,7 +1213,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">163</span>
+    <span class="phpdocumentor-element-found-in__line">165</span>
 
     </aside>
 
@@ -1257,7 +1257,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="core/model/Model.php"><a href="files/core-model-model.html"><abbr title="core/model/Model.php">Model.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">283</span>
+    <span class="phpdocumentor-element-found-in__line">285</span>
 
     </aside>
 

--- a/docs/classes/Core-Router-Router.html
+++ b/docs/classes/Core-Router-Router.html
@@ -593,7 +593,7 @@
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">apiResource</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$uri</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$controller</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">apiResource</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$uri</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$controller</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
         <section class="phpdocumentor-description"></section>
 
@@ -609,7 +609,7 @@
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$controller</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>

--- a/docs/files/app-middlewares-allowcors.html
+++ b/docs/files/app-middlewares-allowcors.html
@@ -76,7 +76,7 @@
                 
             </li>
                     <li>
-                <a href="namespaces/app-middlewares.html" class="-active">Middlewares</a>
+                <a href="namespaces/app-middlewares.html" class="">Middlewares</a>
                 
             </li>
                     <li>
@@ -171,13 +171,18 @@
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="namespaces/app.html">App</a></li>
     </ul>
 
-    <article class="phpdocumentor-element -namespace">
-        <h2 class="phpdocumentor-content__title">Middlewares</h2>
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">AllowCORS.php</h2>
 
         
+    <section class="phpdocumentor-description"></section>
+
+
+
+
+
 
 <h3 id="interfaces_class_traits">
     Interfaces, Classes, Traits and Enums
@@ -188,11 +193,11 @@
     
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-AllowCORS.html"><abbr title="\App\Middlewares\AllowCORS">AllowCORS</abbr></a></dt>
         <dd></dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-Logger.html"><abbr title="\App\Middlewares\Logger">Logger</abbr></a></dt>
-        <dd></dd>
     
     
     </dl>
+
+
 
 
 
@@ -213,7 +218,7 @@
 </section>
             </div>
         </div>
-        <a href="namespaces/app-middlewares.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/app-middlewares-allowcors.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 

--- a/docs/indices/files.html
+++ b/docs/indices/files.html
@@ -174,6 +174,7 @@
     <h2 class="phpdocumentor-content__title">Files</h2>
                             <h3>A</h3>
         <ul class="phpdocumentor-list">
+                    <li><a href="files/app-middlewares-allowcors.html"><abbr title="app/middlewares/AllowCORS.php">AllowCORS.php</abbr></a></li>
                     <li><a href="files/core-exception-appexception.html"><abbr title="core/exception/AppException.php">AppException.php</abbr></a></li>
                     <li><a href="files/app-bootstrap-appserviceprovider.html"><abbr title="app/bootstrap/AppServiceProvider.php">AppServiceProvider.php</abbr></a></li>
                     <li><a href="files/core-main-application.html"><abbr title="core/main/Application.php">Application.php</abbr></a></li>

--- a/docs/js/searchIndex.js
+++ b/docs/js/searchIndex.js
@@ -76,6 +76,16 @@ Search.appendIndex(
             "summary": "",
             "url": "classes/App-Exceptions-Handler.html#method_handle"
         },                {
+            "fqsen": "\\App\\Middlewares\\AllowCORS",
+            "name": "AllowCORS",
+            "summary": "",
+            "url": "classes/App-Middlewares-AllowCORS.html"
+        },                {
+            "fqsen": "\\App\\Middlewares\\AllowCORS\u003A\u003Ahandle\u0028\u0029",
+            "name": "handle",
+            "summary": "",
+            "url": "classes/App-Middlewares-AllowCORS.html#method_handle"
+        },                {
             "fqsen": "\\App\\Middlewares\\Logger",
             "name": "Logger",
             "summary": "",

--- a/docs/js/searchIndex.js
+++ b/docs/js/searchIndex.js
@@ -186,20 +186,60 @@ Search.appendIndex(
             "summary": "",
             "url": "classes/Core-Console-Builder.html#method_getCommandContent"
         },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003ABUILD_MODEL",
+            "name": "BUILD_MODEL",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#constant_BUILD_MODEL"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003ABUILD_CONTROLLER",
+            "name": "BUILD_CONTROLLER",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#constant_BUILD_CONTROLLER"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003ABUILD_MIDDLEWARE",
+            "name": "BUILD_MIDDLEWARE",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#constant_BUILD_MIDDLEWARE"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003ABUILD_COMMAND",
+            "name": "BUILD_COMMAND",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#constant_BUILD_COMMAND"
+        },                {
             "fqsen": "\\Core\\Console\\Builder\u003A\u003ABUILD_COMMANDS",
             "name": "BUILD_COMMANDS",
             "summary": "",
             "url": "classes/Core-Console-Builder.html#constant_BUILD_COMMANDS"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024name",
+            "name": "name",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#property_name"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024forceCreate",
+            "name": "forceCreate",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#property_forceCreate"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024modelConfig",
+            "name": "modelConfig",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#property_modelConfig"
+        },                {
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024controllerConfig",
+            "name": "controllerConfig",
+            "summary": "",
+            "url": "classes/Core-Console-Builder.html#property_controllerConfig"
         },                {
             "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024resource",
             "name": "resource",
             "summary": "",
             "url": "classes/Core-Console-Builder.html#property_resource"
         },                {
-            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024name",
-            "name": "name",
+            "fqsen": "\\Core\\Console\\Builder\u003A\u003A\u0024args",
+            "name": "args",
             "summary": "",
-            "url": "classes/Core-Console-Builder.html#property_name"
+            "url": "classes/Core-Console-Builder.html#property_args"
         },                {
             "fqsen": "\\Core\\Console\\Command",
             "name": "Command",
@@ -301,6 +341,31 @@ Search.appendIndex(
             "summary": "",
             "url": "classes/Core-Console-Helper.html#method_logAllCommands"
         },                {
+            "fqsen": "\\Core\\Console\\Helper\u003A\u003AgreenText\u0028\u0029",
+            "name": "greenText",
+            "summary": "",
+            "url": "classes/Core-Console-Helper.html#method_greenText"
+        },                {
+            "fqsen": "\\Core\\Console\\Helper\u003A\u003AyellowText\u0028\u0029",
+            "name": "yellowText",
+            "summary": "",
+            "url": "classes/Core-Console-Helper.html#method_yellowText"
+        },                {
+            "fqsen": "\\Core\\Console\\Helper\u003A\u003ApurpleText\u0028\u0029",
+            "name": "purpleText",
+            "summary": "",
+            "url": "classes/Core-Console-Helper.html#method_purpleText"
+        },                {
+            "fqsen": "\\Core\\Console\\Helper\u003A\u003AredText\u0028\u0029",
+            "name": "redText",
+            "summary": "",
+            "url": "classes/Core-Console-Helper.html#method_redText"
+        },                {
+            "fqsen": "\\Core\\Console\\Helper\u003A\u003AblueText\u0028\u0029",
+            "name": "blueText",
+            "summary": "",
+            "url": "classes/Core-Console-Helper.html#method_blueText"
+        },                {
             "fqsen": "\\Core\\Console\\Input",
             "name": "Input",
             "summary": "",
@@ -335,6 +400,11 @@ Search.appendIndex(
             "name": "logRoutes",
             "summary": "",
             "url": "classes/Core-Console-Lister.html#method_logRoutes"
+        },                {
+            "fqsen": "\\Core\\Console\\Lister\u003A\u003AlogAllRoutes\u0028\u0029",
+            "name": "logAllRoutes",
+            "summary": "",
+            "url": "classes/Core-Console-Lister.html#method_logAllRoutes"
         },                {
             "fqsen": "\\Core\\Console\\Lister\u003A\u003A\u0024router",
             "name": "router",

--- a/docs/packages/Elemental.html
+++ b/docs/packages/Elemental.html
@@ -197,6 +197,8 @@
         <dd></dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Exceptions-Handler.html"><abbr title="\App\Exceptions\Handler">Handler</abbr></a></dt>
         <dd></dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-AllowCORS.html"><abbr title="\App\Middlewares\AllowCORS">AllowCORS</abbr></a></dt>
+        <dd></dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Middlewares-Logger.html"><abbr title="\App\Middlewares\Logger">Logger</abbr></a></dt>
         <dd></dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/App-Models-User.html"><abbr title="\App\Models\User">User</abbr></a></dt>


### PR DESCRIPTION
This PR adds the following functionality:

- A new middleware to easily allow CORS: `AllowCORS`
- Add `candle list` command to `candle help`
- Fix typos and reformat README docs
- Refresh API documentation
- Minor formatting and style fixes